### PR TITLE
Liferay7 image recommendations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ ONBUILD COPY ./deploy/ /tmp
 WORKDIR /usr/local
 
 RUN mkdir -p "$LIFERAY_HOME" \
-			&& set -x \
-			&& curl -fSL "$LIFERAY_TOMCAT_URL" -o liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip \
-			&& unzip liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip \
-			&& rm liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip \
+      && set -x \
+      && curl -fSL "$LIFERAY_TOMCAT_URL" -o liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip \
+      && unzip liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip \
+      && rm liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip \
       && chown -R liferay:liferay $LIFERAY_HOME \
       && wget -O /usr/local/bin/gosu "$GOSU_URL/gosu-$(dpkg --print-architecture)" \
       && wget -O /usr/local/bin/gosu.asc "$GOSU_URL/gosu-$(dpkg --print-architecture).asc" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
 
 ENV LIFERAY_HOME=/usr/local/liferay-ce-portal-7.0-ga4
 ENV LIFERAY_SHARED=/storage/liferay
-ENV LIFERAY_MYSQL_ROOT_PASSWORD=liferay
 ENV LIFERAY_WEB_SERVER_PROTOCOL=https
 ENV LIFERAY_CONFIG_DIR=/tmp/liferay/configs
 ENV LIFERAY_DEPLOY_DIR=/tmp/liferay/deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ENV LIFERAY_HOME=/usr/local/liferay-ce-portal-7.0-ga4
 ENV CATALINA_HOME=$LIFERAY_HOME/tomcat-8.0.32
 ENV PATH=$CATALINA_HOME/bin:$PATH
 ENV LIFERAY_TOMCAT_URL=https://sourceforge.net/projects/lportal/files/Liferay%20Portal/7.0.3%20GA4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip/download
+ENV GOSU_VERSION 1.10
+ENV GOSU_URL=https://github.com/tianon/gosu/releases/download/$GOSU_VERSION
 
 WORKDIR /usr/local
 
@@ -19,7 +21,15 @@ RUN mkdir -p "$LIFERAY_HOME" \
 			&& curl -fSL "$LIFERAY_TOMCAT_URL" -o liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip \
 			&& unzip liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip \
 			&& rm liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip \
-      && chown -R liferay:liferay $LIFERAY_HOME
+      && chown -R liferay:liferay $LIFERAY_HOME \
+      && wget -O /usr/local/bin/gosu "$GOSU_URL/gosu-$(dpkg --print-architecture)" \
+      && wget -O /usr/local/bin/gosu.asc "$GOSU_URL/gosu-$(dpkg --print-architecture).asc" \
+      && export GNUPGHOME="$(mktemp -d)" \
+      && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+      && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+      && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+      && chmod +x /usr/local/bin/gosu \
+      && gosu nobody true
 
 EXPOSE 8080/tcp
 EXPOSE 11311/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir -p "$LIFERAY_HOME" \
 EXPOSE 8080/tcp
 EXPOSE 11311/tcp
 
-USER liferay
 VOLUME /storage
 
 ENTRYPOINT ["entrypoint.sh"]
+CMD ["catalina.sh", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ ENV LIFERAY_HOME=/usr/local/liferay-ce-portal-7.0-ga4
 ENV LIFERAY_SHARED=/storage/liferay
 ENV LIFERAY_MYSQL_ROOT_PASSWORD=liferay
 ENV LIFERAY_WEB_SERVER_PROTOCOL=https
+ENV LIFERAY_CONFIG_DIR=/tmp/liferay/configs
+ENV LIFERAY_DEPLOY_DIR=/tmp/liferay/deploy
 ENV CATALINA_HOME=$LIFERAY_HOME/tomcat-8.0.32
 ENV PATH=$CATALINA_HOME/bin:$PATH
 ENV LIFERAY_TOMCAT_URL=https://sourceforge.net/projects/lportal/files/Liferay%20Portal/7.0.3%20GA4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip/download
 ENV GOSU_VERSION 1.10
 ENV GOSU_URL=https://github.com/tianon/gosu/releases/download/$GOSU_VERSION
-ENV CONFIG_DIR=/tmp/configs
-ENV DEPLOY_DIR=/tmp/deploy
 
 WORKDIR /usr/local
 
@@ -39,8 +39,8 @@ RUN mkdir -p "$LIFERAY_HOME" \
 COPY ./entrypoint.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-ONBUILD COPY ./configs/ /tmp/configs/
-ONBUILD COPY ./deploy/ /tmp/deploy/
+ONBUILD COPY ./configs/ $LIFERAY_CONFIG_DIR
+ONBUILD COPY ./deploy/ $LIFERAY_DEPLOY_DIR
 
 EXPOSE 8080/tcp
 EXPOSE 11311/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 ENV LIFERAY_HOME=/usr/local/liferay-ce-portal-7.0-ga4
 ENV LIFERAY_SHARED=/storage/liferay
 ENV LIFERAY_MYSQL_ROOT_PASSWORD=liferay
+ENV LIFERAY_WEB_SERVER_PROTOCOL=https
 ENV CATALINA_HOME=$LIFERAY_HOME/tomcat-8.0.32
 ENV PATH=$CATALINA_HOME/bin:$PATH
 ENV LIFERAY_TOMCAT_URL=https://sourceforge.net/projects/lportal/files/Liferay%20Portal/7.0.3%20GA4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip/download
@@ -17,10 +18,6 @@ ENV GOSU_VERSION 1.10
 ENV GOSU_URL=https://github.com/tianon/gosu/releases/download/$GOSU_VERSION
 ENV CONFIG_DIR=/tmp/configs
 ENV DEPLOY_DIR=/tmp/deploy
-
-COPY ./entrypoint.sh /usr/local/bin
-ONBUILD COPY ./configs/ /tmp/configs/
-ONBUILD COPY ./deploy/ /tmp/deploy/
 
 WORKDIR /usr/local
 
@@ -37,8 +34,13 @@ RUN mkdir -p "$LIFERAY_HOME" \
       && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
       && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
       && chmod +x /usr/local/bin/gosu \
-      && gosu nobody true \
-      && chmod +x /usr/local/bin/entrypoint.sh
+      && gosu nobody true
+
+COPY ./entrypoint.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ONBUILD COPY ./configs/ /tmp/configs/
+ONBUILD COPY ./deploy/ /tmp/deploy/
 
 EXPOSE 8080/tcp
 EXPOSE 11311/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
 
 ENV LIFERAY_HOME=/usr/local/liferay-ce-portal-7.0-ga4
 ENV LIFERAY_SHARED=/storage/liferay
+ENV LIFERAY_MYSQL_ROOT_PASSWORD=liferay
 ENV CATALINA_HOME=$LIFERAY_HOME/tomcat-8.0.32
 ENV PATH=$CATALINA_HOME/bin:$PATH
 ENV LIFERAY_TOMCAT_URL=https://sourceforge.net/projects/lportal/files/Liferay%20Portal/7.0.3%20GA4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip/download

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ENV CONFIG_DIR=/tmp/configs
 ENV DEPLOY_DIR=/tmp/deploy
 
 COPY ./entrypoint.sh /usr/local/bin
-ONBUILD COPY ./configs/ /tmp
-ONBUILD COPY ./deploy/ /tmp
+ONBUILD COPY ./configs/ /tmp/configs/
+ONBUILD COPY ./deploy/ /tmp/deploy/
 
 WORKDIR /usr/local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
   && useradd -ms /bin/bash liferay
 
 ENV LIFERAY_HOME=/usr/local/liferay-ce-portal-7.0-ga4
+ENV LIFERAY_SHARED=/storage/liferay
 ENV CATALINA_HOME=$LIFERAY_HOME/tomcat-8.0.32
 ENV PATH=$CATALINA_HOME/bin:$PATH
 ENV LIFERAY_TOMCAT_URL=https://sourceforge.net/projects/lportal/files/Liferay%20Portal/7.0.3%20GA4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip/download
@@ -42,5 +43,6 @@ EXPOSE 8080/tcp
 EXPOSE 11311/tcp
 
 USER liferay
+VOLUME /storage
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mdelapenya/jdk:8-openjdk
 MAINTAINER Manuel de la Peña <manuel.delapenya@liferay.com>
 
 RUN apt-get update \
-  && apt-get install -y curl \
+  && apt-get install -y curl tree \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && useradd -ms /bin/bash liferay
@@ -13,6 +13,12 @@ ENV PATH=$CATALINA_HOME/bin:$PATH
 ENV LIFERAY_TOMCAT_URL=https://sourceforge.net/projects/lportal/files/Liferay%20Portal/7.0.3%20GA4/liferay-ce-portal-tomcat-7.0-ga4-20170613175008905.zip/download
 ENV GOSU_VERSION 1.10
 ENV GOSU_URL=https://github.com/tianon/gosu/releases/download/$GOSU_VERSION
+ENV CONFIG_DIR=/tmp/configs
+ENV DEPLOY_DIR=/tmp/deploy
+
+COPY ./entrypoint.sh /usr/local/bin
+ONBUILD COPY ./configs/ /tmp
+ONBUILD COPY ./deploy/ /tmp
 
 WORKDIR /usr/local
 
@@ -29,11 +35,12 @@ RUN mkdir -p "$LIFERAY_HOME" \
       && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
       && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
       && chmod +x /usr/local/bin/gosu \
-      && gosu nobody true
+      && gosu nobody true \
+      && chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 8080/tcp
 EXPOSE 11311/tcp
 
 USER liferay
 
-ENTRYPOINT ["catalina.sh", "run"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ show_motd() {
 }
 
 prepare_liferay_deploy_directory() {
-  if [ ! -f $DEPLOY_DIR/* ]; then
+  if [ ! -f $LIFERAY_DEPLOY_DIR/* ]; then
     echo "No deploy files found.
   If you wish to deploy customizations to Liferay make
   sure you include a 'deploy' directory in the root of 
@@ -34,12 +34,12 @@ prepare_liferay_deploy_directory() {
   The following contents are going to be synchronized
   with Liferay:
   "
-  tree $DEPLOY_DIR
+  tree $LIFERAY_DEPLOY_DIR
 
-  [ -f $DEPLOY_DIR/*.lpkg ] && cp $DEPLOY_DIR/*.lpkg $LIFERAY_HOME/osgi/marketplace
-  [ -f $DEPLOY_DIR/*.jar ] && cp $DEPLOY_DIR/*.jar $LIFERAY_HOME/osgi/modules
-  [ -f $DEPLOY_DIR/*.war ] && cp $DEPLOY_DIR/*.war $LIFERAY_HOME/osgi/war
-  [ -f $DEPLOY_DIR/*.xml ] && cp $DEPLOY_DIR/*.xml $LIFERAY_HOME/deploy
+  [ -f $LIFERAY_DEPLOY_DIR/*.lpkg ] && cp $LIFERAY_DEPLOY_DIR/*.lpkg $LIFERAY_HOME/osgi/marketplace
+  [ -f $LIFERAY_DEPLOY_DIR/*.jar ] && cp $LIFERAY_DEPLOY_DIR/*.jar $LIFERAY_HOME/osgi/modules
+  [ -f $LIFERAY_DEPLOY_DIR/*.war ] && cp $LIFERAY_DEPLOY_DIR/*.war $LIFERAY_HOME/osgi/war
+  [ -f $LIFERAY_DEPLOY_DIR/*.xml ] && cp $LIFERAY_DEPLOY_DIR/*.xml $LIFERAY_HOME/deploy
 
   echo "
   Continuing.
@@ -47,7 +47,7 @@ prepare_liferay_deploy_directory() {
 }
 
 prepare_liferay_osgi_configs_directory() {
-  if [[ ! -d "$CONFIG_DIR/osgi" ]]; then
+  if [[ ! -d "$LIFERAY_CONFIG_DIR/osgi" ]]; then
     echo "No 'configs/osgi' directory found.
   If you wish to deploy custom OSGi configurations to
   Liferay make sure you include a 'configs/osgi' directory
@@ -63,9 +63,9 @@ prepare_liferay_osgi_configs_directory() {
   with Liferay:
   "
 
-  tree $CONFIG_DIR/osgi
+  tree $LIFERAY_CONFIG_DIR/osgi
   mkdir -p $LIFERAY_HOME/osgi/configs
-  cp -r $CONFIG_DIR/osgi/* $LIFERAY_HOME/osgi/configs 2>/dev/null || true
+  cp -r $LIFERAY_CONFIG_DIR/osgi/* $LIFERAY_HOME/osgi/configs 2>/dev/null || true
 
   echo "
   Continuing.
@@ -73,7 +73,7 @@ prepare_liferay_osgi_configs_directory() {
 }
 
 prepare_liferay_portal_properties() {
-  if [[ ! -f "$CONFIG_DIR/portal-ext.properties" ]]; then
+  if [[ ! -f "$LIFERAY_CONFIG_DIR/portal-ext.properties" ]]; then
     echo "No 'configs/portal-ext.properties' file found.
   If you wish to use a custom properties file make sure
   you include a 'configs/portal-ext.properties' file in the 
@@ -87,7 +87,7 @@ prepare_liferay_portal_properties() {
   echo "Portal properties (portal-ext.properties) file found.
   "
 
-  cp -r $CONFIG_DIR/portal-ext.properties $LIFERAY_HOME/portal-ext.properties
+  cp -r $LIFERAY_CONFIG_DIR/portal-ext.properties $LIFERAY_HOME/portal-ext.properties
 
   sed -i -e "s/jdbc\.default\.password=liferay$/jdbc\.default\.password=$LIFERAY_MYSQL_ROOT_PASSWORD/g" $LIFERAY_HOME/portal-ext.properties
 
@@ -99,7 +99,7 @@ prepare_liferay_portal_properties() {
 }
 
 prepare_liferay_tomcat_config() {
-  if [[ ! -f "$CONFIG_DIR/setenv.sh" ]]; then
+  if [[ ! -f "$LIFERAY_CONFIG_DIR/setenv.sh" ]]; then
     echo "No 'configs/setenv.sh' file found.
   If you wish to provide custom tomcat JVM settings, make sure
   you include a 'configs/setenv.sh' file in the 
@@ -113,7 +113,7 @@ prepare_liferay_tomcat_config() {
   echo "Tomcat configuration (setenv.sh) file found.
   "
 
-  cp -r $CONFIG_DIR/setenv.sh $CATALINA_HOME/bin/setenv.sh
+  cp -r $LIFERAY_CONFIG_DIR/setenv.sh $CATALINA_HOME/bin/setenv.sh
 
   echo "
   Continuing.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,10 +33,12 @@ prepare_liferay_deploy_directory() {
   The following contents are going to be synchronized
   with Liferay:
   "
-
   tree $DEPLOY_DIR
-  mkdir -p $LIFERAY_HOME/deploy
-  cp -r $DEPLOY_DIR/* $LIFERAY_HOME/deploy
+
+  [ -f $DEPLOY_DIR/*.lpkg ] && cp $DEPLOY_DIR/*.lpkg $LIFERAY_HOME/osgi/marketplace
+  [ -f $DEPLOY_DIR/*.jar ] && cp $DEPLOY_DIR/*.jar $LIFERAY_HOME/osgi/modules
+  [ -f $DEPLOY_DIR/*.war ] && cp $DEPLOY_DIR/*.war $LIFERAY_HOME/osgi/war
+  [ -f $DEPLOY_DIR/*.xml ] && cp $DEPLOY_DIR/*.xml $LIFERAY_HOME/deploy
 
   echo "
   Continuing.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -o errexit
+
+main() {
+  show_motd
+  prepare_liferay_portal_properties
+  prepare_liferay_deploy_directory
+  prepare_liferay_osgi_configs_directory
+  run_portal
+}
+
+show_motd() {
+  echo "Starting Liferay 7 instance.
+
+  LIFERAY_HOME: $LIFERAY_HOME
+  "
+}
+
+prepare_liferay_deploy_directory() {
+  if [ ! -f $DEPLOY_DIR/* ]; then
+    echo "No deploy files found.
+  If you wish to deploy customizations to Liferay make
+  sure you include a 'deploy' directory in the root of 
+  your project.
+
+  Continuing.
+  "
+    return 0
+  fi
+
+  echo "Deploy directory found.
+  The following contents are going to be synchronized
+  with Liferay:
+  "
+
+  tree $DEPLOY_DIR
+  mkdir -p $LIFERAY_HOME/deploy
+  cp -r $DEPLOY_DIR/* $LIFERAY_HOME/deploy
+
+  echo "
+  Continuing.
+  "
+}
+
+prepare_liferay_osgi_configs_directory() {
+  if [[ ! -d "$CONFIG_DIR/osgi" ]]; then
+    echo "No 'configs/osgi' directory found.
+  If you wish to deploy custom OSGi configurations to
+  Liferay make sure you include a 'configs/osgi' directory
+  in the root of your project.
+
+  Continuing.
+  "
+    return 0
+  fi
+
+  echo "OSGi configs directory found.
+  The following contents are going to be synchronized
+  with Liferay:
+  "
+
+  tree $CONFIG_DIR/osgi
+  mkdir -p $LIFERAY_HOME/osgi/configs
+  cp -r $CONFIG_DIR/osgi/* $LIFERAY_HOME/osgi/configs 2>/dev/null || true
+
+  echo "
+  Continuing.
+  "
+}
+
+prepare_liferay_portal_properties() {
+  if [[ ! -f "$CONFIG_DIR/portal-ext.properties" ]]; then
+    echo "No 'portal-ext.properties' file found.
+  If you wish to use a custom properties file make sure
+  you include a 'portal-ext.properties' file in the 
+  root of your project.
+
+  Continuing.
+  "
+    return 0
+  fi
+
+  echo "Portal properties (portal-ext.properties) file found.
+  "
+
+  cp -r $CONFIG_DIR/portal-ext.properties $LIFERAY_HOME/portal-ext.properties
+
+  echo "
+  Continuing.
+  "
+}
+
+run_portal() {
+  exec catalina.sh run
+}
+
+main "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,6 +90,8 @@ prepare_liferay_portal_properties() {
 
   sed -i -e "s/jdbc\.default\.password=liferay$/jdbc\.default\.password=$LIFERAY_MYSQL_ROOT_PASSWORD/g" $LIFERAY_HOME/portal-ext.properties
 
+  sed -i -e "s/web\.server\.protocol=https$/web\.server\.protocol=$LIFERAY_WEB_SERVER_PROTOCOL/g" $LIFERAY_HOME/portal-ext.properties
+
   echo "
   Continuing.
   "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,8 +89,6 @@ prepare_liferay_portal_properties() {
 
   cp -r $LIFERAY_CONFIG_DIR/portal-ext.properties $LIFERAY_HOME/portal-ext.properties
 
-  sed -i -e "s/jdbc\.default\.password=liferay$/jdbc\.default\.password=$LIFERAY_MYSQL_ROOT_PASSWORD/g" $LIFERAY_HOME/portal-ext.properties
-
   sed -i -e "s/web\.server\.protocol=https$/web\.server\.protocol=$LIFERAY_WEB_SERVER_PROTOCOL/g" $LIFERAY_HOME/portal-ext.properties
 
   echo "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,9 +73,9 @@ prepare_liferay_osgi_configs_directory() {
 
 prepare_liferay_portal_properties() {
   if [[ ! -f "$CONFIG_DIR/portal-ext.properties" ]]; then
-    echo "No 'portal-ext.properties' file found.
+    echo "No 'configs/portal-ext.properties' file found.
   If you wish to use a custom properties file make sure
-  you include a 'portal-ext.properties' file in the 
+  you include a 'configs/portal-ext.properties' file in the 
   root of your project.
 
   Continuing.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ set -o errexit
 main() {
   show_motd
   prepare_liferay_portal_properties
+  prepare_liferay_tomcat_config
   prepare_liferay_deploy_directory
   prepare_liferay_osgi_configs_directory
   run_portal "$@"
@@ -91,6 +92,28 @@ prepare_liferay_portal_properties() {
   sed -i -e "s/jdbc\.default\.password=liferay$/jdbc\.default\.password=$LIFERAY_MYSQL_ROOT_PASSWORD/g" $LIFERAY_HOME/portal-ext.properties
 
   sed -i -e "s/web\.server\.protocol=https$/web\.server\.protocol=$LIFERAY_WEB_SERVER_PROTOCOL/g" $LIFERAY_HOME/portal-ext.properties
+
+  echo "
+  Continuing.
+  "
+}
+
+prepare_liferay_tomcat_config() {
+  if [[ ! -f "$CONFIG_DIR/setenv.sh" ]]; then
+    echo "No 'configs/setenv.sh' file found.
+  If you wish to provide custom tomcat JVM settings, make sure
+  you include a 'configs/setenv.sh' file in the 
+  root of your project.
+
+  Continuing.
+  "
+    return 0
+  fi
+
+  echo "Tomcat configuration (setenv.sh) file found.
+  "
+
+  cp -r $CONFIG_DIR/setenv.sh $CATALINA_HOME/bin/setenv.sh
 
   echo "
   Continuing.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,6 +88,8 @@ prepare_liferay_portal_properties() {
 
   cp -r $CONFIG_DIR/portal-ext.properties $LIFERAY_HOME/portal-ext.properties
 
+  sed -i -e "s/jdbc\.default\.password=liferay$/jdbc\.default\.password=$LIFERAY_MYSQL_ROOT_PASSWORD/g" $LIFERAY_HOME/portal-ext.properties
+
   echo "
   Continuing.
   "


### PR DESCRIPTION
Hi @mdelapenya,

I’ve been testing some things with Docker and WeDeploy and made some changes to the Liferay 7 image.  These changes could also be adapted to the Liferay DXP image if they are useful. 

Here are some changes that I made:

- Made it so the Liferay 7 image uses gosu to drop privileges to the liferay user when it starts Liferay.
- Makes sure the shared volume permissions are fixed during the init process.
- Deploy applications to their final locations instead of the deploy directory. (Will help with clustering since placing osgi dir on shared storage will cause an issue between nodes)
- Add a variable to set the db password.
- Shared Volume now only includes document_library.  This change speeds up deploy to WeDeploy from 16 mins to 1.5 min.
- Configure Shared Volume to reside on /storage.  This will help with WeDeploy putting everything in the root of the shared volume which could have unforeseen issues.